### PR TITLE
a basic example

### DIFF
--- a/basic-example.js
+++ b/basic-example.js
@@ -1,0 +1,21 @@
+'use strict';
+var fs = require('fs'),
+  twigger = require('pattern-importer').twigCompiler;
+
+var menuPath = './app/PUBLIC/menu.html';
+var navHtml = fs.readFileSync(menuPath);
+var data = {
+  menu: navHtml
+}
+var destPath = './app/basic-example.html';
+var twigTemplate = './node_modules/pattern-presenter/templates/dev-interface.twig';
+
+var finalFile = twigger(twigTemplate,data);
+fs.writeFile(destPath, finalFile,
+
+  function (err) {
+    if (err) { return console.error(err) }
+    console.log('basic-example.html is generated!');
+  }
+);
+

--- a/templates/dev-interface.twig
+++ b/templates/dev-interface.twig
@@ -1,5 +1,12 @@
 
-The menu is here:
-
+    <link rel="stylesheet" href="styles/nav.css">
+<div class="nav">
 {{menu}}
+</div>
+<iframe id="viewport" sandbox="allow-same-origin allow-scripts" src="http://localhost:8001/PUBLIC/base/a/a.html"></iframe>
 
+<script type="text/javascript">
+  function iframechange(url){
+    document.getElementById('viewport').src = url;
+  }
+</script>

--- a/templates/menu-basic.twig
+++ b/templates/menu-basic.twig
@@ -1,0 +1,25 @@
+{% if categories is not empty %}
+  <ul class="patterns-menu">
+    {% for key,value in categories %}
+      {% if value.patterns is not empty %}
+        <li>{{key}}<ul>
+        {% if value.subcategories is not empty %}
+          {% for key,value in value.subcategories %}
+            {% if value.patterns is not empty %}
+             <li>{{key}}
+              <ul>
+              {% for item in value.patterns %}
+                <li><a href="Javascript:;" onclick="iframechange('{{item.url}}')">{{item.name}}</a></li>
+              {% endfor %}
+              </ul></li>
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+        {% for item in value.patterns %}
+          <li><a href="Javascript:;" onclick="iframechange('{{item.url}}')">{{item.name}}</a></li>
+        {% endfor %}
+        </ul></li>
+      {% endif %}
+    {% endfor %}
+  </ul>
+{% endif %}

--- a/templates/nav.css
+++ b/templates/nav.css
@@ -1,0 +1,62 @@
+iframe#viewport {
+  width: 100%;
+  height: 75%;
+}
+
+.nav {
+}
+
+.nav ul ul {
+  display: none;
+}
+
+  .nav ul li:hover > ul {
+    display: block;
+  }
+
+
+.nav ul {
+  background: #efefef;
+  list-style: none;
+  position: relative;
+  display: inline-table;
+}
+  .nav ul:after {
+    content: ""; clear: both; display: block;
+  }
+
+  .nav ul li {
+    float: left;
+    padding: 0 1em;
+  }
+    .nav ul li:hover {
+      background: #4b545f;
+    }
+      .nav ul li:hover a {
+      }
+
+    .nav ul li a {
+      display: block;
+      text-decoration: none;
+    }
+
+
+  .nav ul ul {
+    padding: 0;
+    position: absolute;
+    top: 100%;
+  }
+    .nav ul ul li {
+      float: none;
+      position: relative;
+    }
+      .nav ul ul li a {
+      }
+        .nav ul ul li a:hover {
+          background: #4b545f;
+        }
+
+  .nav ul ul ul {
+    position: absolute;
+    top:0;
+  }


### PR DESCRIPTION
@sergesemashko @beynya 

This creates a very basic interface which includes an iframe and extremely simple javascript to fill the iframe.

If we go with a route more like this it will open up our ability to expand on the functionality without spending all the time figuring out what PatterLab is doing.

In order to build the menu originally, I used the built-in gulp task `patterns-menu` like so:

```
var menuOptions = {
  src: './node_modules/pattern-presenter/templates/menu-basic.twig',
  dest: './app/PUBLIC/menu.html'
}
require('pattern-presenter').gulpPatternsMenu(require('gulp'),menuOptions);
```